### PR TITLE
HPCC-34305 Cleanup deprecated windows-2019 runner

### DIFF
--- a/.github/workflows/prebuild-gh_envs.yml
+++ b/.github/workflows/prebuild-gh_envs.yml
@@ -24,7 +24,7 @@ jobs:
         label:
           [
             "ubuntu-22.04-x64",
-            "windows-2019-x64",
+            "windows-2025-x64",
             "windows-2022-x64",
             "macos-13-x64",
             "macos-14-arm64"
@@ -35,8 +35,8 @@ jobs:
             triplet: "x64-linux-dynamic"
             mono: "mono"
             sudo: "sudo"
-          - label: "windows-2019-x64"
-            os: "windows-2019"
+          - label: "windows-2025-x64"
+            os: "windows-2025"
             triplet: "x64-windows"
             mono: ""
             sudo: ""


### PR DESCRIPTION
Removed 2019 and added 2025 runner.  Test run here https://github.com/Michael-Gardner/vcpkg/actions/runs/15563553483/job/43821813189